### PR TITLE
Actualización de versión a 0.2.0 y configuración de versionado dinámico

### DIFF
--- a/plak/__init__.py
+++ b/plak/__init__.py
@@ -1,2 +1,2 @@
 __app_name__ = "plak"
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,13 @@ requires-python = "<4.0,>=3.12"
 dependencies = [
     "pytest<9.0.0,>=8.3.2",
     "typer>=0.12.5",
+    "rich>=13.7.0",
+    "questionary>=2.0.1",
+    "textual>=0.52.1",
 ]
 name = "plak"
-version = "0.1.0"
+# La versión ahora se obtiene dinámicamente de __init__.py
+dynamic = ["version"]
 description = "Herramienta para gestionar servidores en la nube y sitios en WordPress"
 readme = "README.md"
 
@@ -16,5 +20,8 @@ readme = "README.md"
 plak = "plak.main:app"
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+path = "plak/__init__.py"


### PR DESCRIPTION
## Cambios
- Se ha actualizado la versión a 0.2.0 para reflejar los cambios significativos de la implementación interactiva
- Se ha configurado el sistema para usar un versionado dinámico desde un único archivo
- La versión ahora solo se define en `plak/__init__.py`
- Se agregó `hatch-vcs` como dependencia para el sistema de construcción

## Ventajas
- Fuente única de verdad: La versión ahora solo se define en un lugar (`plak/__init__.py`)
- Consistencia: Evitamos discrepancias entre diferentes archivos
- Facilidad de mantenimiento: Para futuras actualizaciones, solo necesitamos cambiar la versión en un lugar

## Cambios en la configuración
- Se ha añadido `dynamic = ["version"]` a la sección [project] en pyproject.toml
- Se ha añadido [tool.hatch.version] para especificar la ruta del archivo de versión
- Se ha añadido "hatch-vcs" a las dependencias de construcción