### PR TITLE
[codex] migrate Plak to Bash + gum

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,18 @@ brew install shellcheck shfmt
    ./compile.sh
    ```
 
+## Homebrew Releases
+
+Plak's Homebrew formula is generated from `packaging/homebrew/plak.rb.template`.
+
+After tagging a release, generate the formula for the tap with:
+
+```bash
+./scripts/homebrew_formula.sh 0.3.0 > /tmp/plak.rb
+```
+
+Then copy it to `plakio/homebrew-tap/Formula/plak.rb` and test it with Homebrew. See `docs/homebrew.md` for the full release flow.
+
 ## Safety
 
 - Do not edit `/etc/hosts` without a backup.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,15 +41,15 @@ brew install shellcheck shfmt
 
 ## Homebrew Releases
 
-Plak's Homebrew formula is generated from `packaging/homebrew/plak.rb.template`.
+Plak's Homebrew formula is generated from `packaging/homebrew/plak-cli.rb.template`.
 
 After tagging a release, generate the formula for the tap with:
 
 ```bash
-./scripts/homebrew_formula.sh 0.3.0 > /tmp/plak.rb
+./scripts/homebrew_formula.sh 0.3.0 > /tmp/plak-cli.rb
 ```
 
-Then copy it to `plakio/homebrew-tap/Formula/plak.rb` and test it with Homebrew. See `docs/homebrew.md` for the full release flow.
+Then copy it to `plak/homebrew-plak-cli/Formula/plak-cli.rb` and test it with Homebrew. See `docs/homebrew.md` for the full release flow.
 
 ## Safety
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ It follows a Cove-style structure: modular source files are compiled into a sing
 After the Homebrew tap is published, install Plak with:
 
 ```bash
-brew install plakio/tap/plak
+brew tap plak/plak-cli
+brew install plak-cli
 ```
 
 For local development, Plak can also install/check `gum` with Homebrew:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,15 @@ It follows a Cove-style structure: modular source files are compiled into a sing
 - `ssh` and `ssh-keygen`
 - `sudo` for writing to `/etc/hosts` when needed
 
-On macOS, Plak can install `gum` with Homebrew:
+## Installation
+
+After the Homebrew tap is published, install Plak with:
+
+```bash
+brew install plakio/tap/plak
+```
+
+For local development, Plak can also install/check `gum` with Homebrew:
 
 ```bash
 ./plak.sh install
@@ -47,6 +55,8 @@ Install the local compiled script as `plak`:
 ```bash
 ./install-plak.sh --dev
 ```
+
+See [docs/homebrew.md](docs/homebrew.md) for release and tap maintenance.
 
 ## Project Structure
 

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -7,14 +7,14 @@ Plak is distributed through a Homebrew tap.
 After the first tap release is published, users can install Plak with:
 
 ```bash
-brew tap plakio/tap
-brew install plak
+brew tap plak/plak-cli
+brew install plak-cli
 ```
 
 Or in one command:
 
 ```bash
-brew install plakio/tap/plak
+brew install plak/plak-cli/plak-cli
 ```
 
 ## Tap Repository
@@ -22,13 +22,13 @@ brew install plakio/tap/plak
 Homebrew expects the tap repository to be named with a `homebrew-` prefix. For Plak, use:
 
 ```text
-plakio/homebrew-tap
+plak/homebrew-plak-cli
 ```
 
 The tap should contain:
 
 ```text
-Formula/plak.rb
+Formula/plak-cli.rb
 README.md
 ```
 
@@ -53,28 +53,28 @@ README.md
 5. Generate the Homebrew formula:
 
    ```bash
-   ./scripts/homebrew_formula.sh 0.3.0 > /tmp/plak.rb
+   ./scripts/homebrew_formula.sh 0.3.0 > /tmp/plak-cli.rb
    ```
 
-6. Copy `/tmp/plak.rb` into the tap repository:
+6. Copy `/tmp/plak-cli.rb` into the tap repository:
 
    ```text
-   plakio/homebrew-tap/Formula/plak.rb
+   plak/homebrew-plak-cli/Formula/plak-cli.rb
    ```
 
 7. In the tap repository, test locally:
 
    ```bash
-   brew install --build-from-source ./Formula/plak.rb
-   brew test ./Formula/plak.rb
-   brew uninstall plak
+   brew install --build-from-source ./Formula/plak-cli.rb
+   brew test ./Formula/plak-cli.rb
+   brew uninstall plak-cli
    ```
 
 8. Commit and push the tap update:
 
    ```bash
-   git add Formula/plak.rb
-   git commit -m "plak 0.3.0"
+   git add Formula/plak-cli.rb
+   git commit -m "plak-cli 0.3.0"
    git push origin main
    ```
 
@@ -83,7 +83,7 @@ README.md
 The source template lives at:
 
 ```text
-packaging/homebrew/plak.rb.template
+packaging/homebrew/plak-cli.rb.template
 ```
 
-It is intentionally checked in as a template because Homebrew requires a real release tarball SHA256. The generated `Formula/plak.rb` belongs in `plakio/homebrew-tap`, not this source repository.
+It is intentionally checked in as a template because Homebrew requires a real release tarball SHA256. The generated `Formula/plak-cli.rb` belongs in `plak/homebrew-plak-cli`, not this source repository.

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -1,0 +1,89 @@
+# Homebrew Distribution
+
+Plak is distributed through a Homebrew tap.
+
+## User Install
+
+After the first tap release is published, users can install Plak with:
+
+```bash
+brew tap plakio/tap
+brew install plak
+```
+
+Or in one command:
+
+```bash
+brew install plakio/tap/plak
+```
+
+## Tap Repository
+
+Homebrew expects the tap repository to be named with a `homebrew-` prefix. For Plak, use:
+
+```text
+plakio/homebrew-tap
+```
+
+The tap should contain:
+
+```text
+Formula/plak.rb
+README.md
+```
+
+## Release Flow
+
+1. Ensure `PLAK_VERSION` in `main` is a stable version, for example `0.3.0`.
+2. Compile and test:
+
+   ```bash
+   ./compile.sh
+   ./tests/smoke.sh
+   ```
+
+3. Merge the release changes into `main`.
+4. Tag and push the release from `main`:
+
+   ```bash
+   git tag v0.3.0
+   git push origin v0.3.0
+   ```
+
+5. Generate the Homebrew formula:
+
+   ```bash
+   ./scripts/homebrew_formula.sh 0.3.0 > /tmp/plak.rb
+   ```
+
+6. Copy `/tmp/plak.rb` into the tap repository:
+
+   ```text
+   plakio/homebrew-tap/Formula/plak.rb
+   ```
+
+7. In the tap repository, test locally:
+
+   ```bash
+   brew install --build-from-source ./Formula/plak.rb
+   brew test ./Formula/plak.rb
+   brew uninstall plak
+   ```
+
+8. Commit and push the tap update:
+
+   ```bash
+   git add Formula/plak.rb
+   git commit -m "plak 0.3.0"
+   git push origin main
+   ```
+
+## Formula Template
+
+The source template lives at:
+
+```text
+packaging/homebrew/plak.rb.template
+```
+
+It is intentionally checked in as a template because Homebrew requires a real release tarball SHA256. The generated `Formula/plak.rb` belongs in `plakio/homebrew-tap`, not this source repository.

--- a/main
+++ b/main
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 PLAK_NAME="plak"
-PLAK_VERSION="0.3.0-dev"
+PLAK_VERSION="0.3.0"
 PLAK_HOME="${PLAK_HOME:-$HOME/.plak}"
 PLAK_SSH_CONFIG="${PLAK_SSH_CONFIG:-$HOME/.ssh/config}"
 PLAK_HOSTS_FILE="${PLAK_HOSTS_FILE:-/etc/hosts}"

--- a/packaging/homebrew/plak-cli.rb.template
+++ b/packaging/homebrew/plak-cli.rb.template
@@ -1,4 +1,4 @@
-class Plak < Formula
+class PlakCli < Formula
   desc "Interactive Bash CLI for SSH servers, local domains, and SSH keys"
   homepage "https://github.com/plakio/plak-cli"
   url "https://github.com/plakio/plak-cli/archive/refs/tags/v__VERSION__.tar.gz"

--- a/packaging/homebrew/plak.rb.template
+++ b/packaging/homebrew/plak.rb.template
@@ -1,0 +1,19 @@
+class Plak < Formula
+  desc "Interactive Bash CLI for SSH servers, local domains, and SSH keys"
+  homepage "https://github.com/plakio/plak-cli"
+  url "https://github.com/plakio/plak-cli/archive/refs/tags/v__VERSION__.tar.gz"
+  sha256 "__SHA256__"
+  license "MIT"
+
+  depends_on "gum"
+
+  def install
+    system "./compile.sh"
+    bin.install "plak.sh" => "plak"
+  end
+
+  test do
+    assert_match "plak v__VERSION__", shell_output("#{bin}/plak version")
+    assert_match "Dependencies:", shell_output("#{bin}/plak status")
+  end
+end

--- a/plak.sh
+++ b/plak.sh
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 PLAK_NAME="plak"
-PLAK_VERSION="0.3.0-dev"
+PLAK_VERSION="0.3.0"
 PLAK_HOME="${PLAK_HOME:-$HOME/.plak}"
 PLAK_SSH_CONFIG="${PLAK_SSH_CONFIG:-$HOME/.ssh/config}"
 PLAK_HOSTS_FILE="${PLAK_HOSTS_FILE:-/etc/hosts}"

--- a/scripts/homebrew_formula.sh
+++ b/scripts/homebrew_formula.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+version="${1:-}"
+if [ -z "$version" ]; then
+    echo "Usage: $0 <version>" >&2
+    echo "Example: $0 0.3.0" >&2
+    exit 1
+fi
+
+version="${version#v}"
+repo_url="https://github.com/plakio/plak-cli/archive/refs/tags/v${version}.tar.gz"
+template="packaging/homebrew/plak.rb.template"
+
+if [ ! -f "$template" ]; then
+    echo "Template not found: $template" >&2
+    exit 1
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+    echo "curl is required." >&2
+    exit 1
+fi
+
+if ! command -v shasum >/dev/null 2>&1; then
+    echo "shasum is required." >&2
+    exit 1
+fi
+
+sha256=$(curl -fsSL "$repo_url" | shasum -a 256 | awk '{ print $1 }')
+
+sed \
+    -e "s/__VERSION__/${version}/g" \
+    -e "s/__SHA256__/${sha256}/g" \
+    "$template"

--- a/scripts/homebrew_formula.sh
+++ b/scripts/homebrew_formula.sh
@@ -11,7 +11,7 @@ fi
 
 version="${version#v}"
 repo_url="https://github.com/plakio/plak-cli/archive/refs/tags/v${version}.tar.gz"
-template="packaging/homebrew/plak.rb.template"
+template="packaging/homebrew/plak-cli.rb.template"
 
 if [ ! -f "$template" ]; then
     echo "Template not found: $template" >&2


### PR DESCRIPTION
## Summary
- Migrates Plak from Python/Typer/Rich to a modular Bash CLI using gum.
- Adds Cove-style compilation into a single `plak.sh` distributable.
- Implements server, domain, sshkey, status, install, and version commands.
- Adds Homebrew packaging support with a formula template, release docs, and a formula generation helper.
- Replaces Python tests with a Bash smoke test.

## Homebrew Notes
- Formula template: `packaging/homebrew/plak.rb.template`
- Release guide: `docs/homebrew.md`
- Formula generator: `scripts/homebrew_formula.sh`
- Version is set to `0.3.0` for the upcoming release.

## Validation
- `./tests/smoke.sh`
- `bash -n main shared/* commands/* compile.sh install-plak.sh scripts/*.sh tests/smoke.sh plak.sh`
- `ruby -c packaging/homebrew/plak.rb.template`
